### PR TITLE
Fix progress message stacking and flickering

### DIFF
--- a/readwisereader.koplugin/main.lua
+++ b/readwisereader.koplugin/main.lua
@@ -1296,8 +1296,6 @@ function ReadwiseReader:downloadDocument(document)
         return "skipped"
     end
     
-    self:showProgress(string.format("Processing: %s", document.title or "Untitled"))
-    
     -- Store author metadata from the API
     self:storeAuthorMetadata(document.id, document.author)
 
@@ -1731,6 +1729,9 @@ function ReadwiseReader:fetchAndEncodeImage(url)
 end
 
 function ReadwiseReader:showProgress(text)
+    if self.progress_message then
+        UIManager:close(self.progress_message)
+    end
     self.progress_message = InfoMessage:new{text = text, timeout = 1}
     UIManager:show(self.progress_message)
     UIManager:forceRePaint()
@@ -1853,17 +1854,15 @@ function ReadwiseReader:synchronize()
     end
     
     local cleaned_count = self:cleanupArchivedDocuments()
-    self:hideProgress()
     
     self:showProgress("Processing finished articles…")
     local archived_count, deleted_count = self:processFinishedDocuments()
-    self:hideProgress()
     
     self:showProgress("Getting document list…")
     local documents = self:getDocumentList()
-    self:hideProgress()
     
     if not documents then
+        self:hideProgress()
         UIManager:show(InfoMessage:new{ text = "Failed to get document list from Readwise Reader." })
         return
     end
@@ -1886,6 +1885,8 @@ function ReadwiseReader:synchronize()
         if existing_count > 0 then
             msg = msg .. "\n" .. string.format("Skipped %d existing articles.", existing_count)
         end
+        
+        self:hideProgress()
         UIManager:show(InfoMessage:new{ text = msg })
         
         self.last_sync_time = sync_start_time
@@ -1898,7 +1899,7 @@ function ReadwiseReader:synchronize()
     local failed = 0
     
     for i, document in ipairs(filtered_documents) do
-        self:showProgress(string.format("Downloading %d of %d…", i, #filtered_documents))
+        self:showProgress(string.format("Downloading %d of %d: %s", i, #filtered_documents, document.title))
         
         local result = self:downloadDocument(document)
         


### PR DESCRIPTION
This fixes the progress messages stacking up during the sync and simplifies the message lifecycle management.

- Refactor `showProgress `to explicitly close existing widgets before creating new ones, preventing UI leaks.
- Remove granular progress updates in `downloadDocument `to eliminate flickering in the main sync loop.
- Consolidate sync loop progress to include document title for better feedback.
- Remove redundant `hideProgress `calls in synchronize.