### PR TITLE
Refactor local document handling and iteration

### DIFF
--- a/readwisereader.koplugin/main.lua
+++ b/readwisereader.koplugin/main.lua
@@ -1295,22 +1295,14 @@ function ReadwiseReader:reconcileLocalDocuments(server_documents)
     local removed_count = 0
 
     -- Scan local directory for Readwise articles
-    for entry in lfs.dir(self.directory) do
-        if entry ~= "." and entry ~= ".." then
-            local filepath = self.directory .. entry
-
-            if lfs.attributes(filepath, "mode") == "file" and entry:find(article_id_prefix, 1, true) then
-                local doc_id = self:getDocumentIdFromPath(filepath)
-
-                if doc_id and not server_ids[doc_id] then
-                    logger.dbg("ReadwiseReader:reconcileLocalDocuments: removing", filepath, "- no longer matches server state")
-                    FileManager:deleteFile(filepath, true)
-                    self:removeAuthorMetadata(doc_id)
-                    removed_count = removed_count + 1
-                end
-            end
+    self:forEachLocalDocument(function(doc_id, filepath)
+        if not server_ids[doc_id] then
+            logger.dbg("ReadwiseReader:reconcileLocalDocuments: removing", filepath, "- no longer matches server state")
+            FileManager:deleteFile(filepath, true)
+            self:removeAuthorMetadata(doc_id)
+            removed_count = removed_count + 1
         end
-    end
+    end)
 
     logger.dbg("ReadwiseReader:reconcileLocalDocuments: removed", removed_count, "articles no longer on server")
     return removed_count


### PR DESCRIPTION
I stumbled upon a problem while implementing metadata sidecar support where `.sdr` folders are picked up instead of the documents because they also matched the filename pattern. I ended up refactoring the document file handling quite a bit to make it more DRY.

- Centralize directory traversal logic into `forEachLocalDocument` helper
- Improve document detection to verify entries are files, not directories (e.g., `.sdr` folders)
- Add `.html` extension filtering for robust and performant document matching
- Optimize filesystem calls by checking extensions before `lfs.attributes`
- Refactor `findLocalDocumentByReadwiseId`, `deleteArticlesWithLocation`, `deleteArticlesWithTag`, and `processFinishedDocuments` to use the new helper
- Simplify `documentExists` by reusing `findLocalDocumentByReadwiseId` logic