### PR TITLE
Map site_name to KOReader series field for filtering

### DIFF
--- a/readwisereader.koplugin/main.lua
+++ b/readwisereader.koplugin/main.lua
@@ -8,7 +8,7 @@
 -- - Downloads articles from Readwise Reader "later" and "shortlist" locations
 -- - Converts articles to HTML format with embedded images
 -- - Generates KOReader metadata sidecars (.sdr) for enhanced library integration
--- - Offers filtering by article tags, location and type
+-- - Offers filtering by article tags, location, type and site name (via series)
 -- - Archives finished articles back to Readwise
 -- - Exports highlights and notes to Readwise
 -- - Handles incremental sync with cleanup of archived content
@@ -238,6 +238,10 @@ function ReadwiseReader:setDocumentMetadata(filepath, document)
 
     if document.summary and document.summary ~= "" then
         props.description = document.summary
+    end
+
+    if document.site_name and document.site_name ~= "" then
+        props.series = document.site_name
     end
 
     -- Both doc_props and custom_props need to exist, otherwise KOReader will crash


### PR DESCRIPTION
I think the source site should be available in KOReader’s metadata so it can be used for filtering - I filter by the site an article came from all the time. Since there isn’t a suitable metadata field for this at the moment, I used the "series" property. That’s a bit of a semantic stretch, but not completely unreasonable.

One idea would be to prefix these values with something like `Site:`  to make them easier to distinguish from actual book series on the device. On the other hand, we don’t add such prefixes to other metadata fields either, so this would introduce a bit of inconsistency.
 
- Update `setDocumentMetadata` to include `site_name` in the `series` property
- Enable source-based filtering and grouping in the KOReader File Manager